### PR TITLE
Fix scraping logic for new degree courses

### DIFF
--- a/link.py
+++ b/link.py
@@ -12,7 +12,10 @@ class CDL():
 SKIP = [
     "Progettazione delle aree verdi e del paesaggio - Interateneo",
     "Scienze viticole ed enologiche - Interateneo",
-    "Artificial Intelligence"
+    "Artificial Intelligence",
+    "Interpretariato e traduzione in lingua dei segni italiana (LIS) e lingua dei segni italiana tattile (LIST)",
+    "Artificial intelligence for science and technology",
+    "Global Environment and Development",
 ]
 
 
@@ -38,15 +41,11 @@ def parser():
         files = soup.find_all("span", class_ = "file-link")
 
         sm = files[0].find("a")["href"]
-        rules = files[1].find("a")["href"]
+        rules = files[1].find("a")["href"] if len(files) > 1 else None
+        aus = files[3].find("a")["href"] if len(files) > 1 else None
         
-        if len(files) == 3:
-            aus = None
-        else:
-            aus = files[3].find("a")["href"]
-        
-        div = soup.find_all("div", class_ = "paragraph paragraph--type--bp-action")[1:]
-        links = [d.find("a")["href"].strip() for d in div]
+        div = soup.find("div", class_ = "views-field views-field-bando-al-servizio")
+        links = [link["href"].strip() for link in div.findChildren("a", recursive=True)]
 
         imm = dict()
         if len(links) == 1:


### PR DESCRIPTION
- Fix di un `IndexError` durante l'accesso ai link a manifesto, regolamento e SUA.
- Modifica della `class` del tag `div` in cui cercare i link per domanda di ammissione, graduatoria e immatricolazione.
- Aggiunta di nuovi CDL da saltare durante lo scraping.

In alcuni casi si presentava un `IndexError` quando nella pagina era presente il manifesto ma non i "documenti ufficiali" (regolamento e SUA). Un esempio è [Ancient Civilizations for the Contemporary World](https://www.unimi.it/it/corsi/laurea-triennale/ancient-civilizations-contemporary-world), un CDL interateneo ma gestito da Unimi, che contiene solo il manifesto ma non (ancora?) il regolamento e la SUA. Una condizione alternativa risolve questo problema.

I link per la domanda di ammissione, la graduatoria e l'immatricolazione sono stati apparentemente spostati sotto un tag con `class` diversa dalla precedente. La nuova `class` consente di accedere nuovamente a questi link.

Sono presenti nuovi corsi di laurea interateneo non gestiti da Unimi, i loro nomi sono stati inseriti nell'elenco `SKIP`.